### PR TITLE
doc - Install from source  - remove last backslash

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -101,7 +101,7 @@ Install required build dependencies before configuring and building dionaea.
         libudns-dev \
         python3 \
         python3-dev \
-        python3-yaml \
+        python3-yaml
 
 After all dependencies have been installed successfully run :code:`autreconf` to build or rebuild the build scripts.
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Documentation

##### SUMMARY
there is one extra backslash at the end of apt-get command



