### PR TITLE
Handle TRANS2 SESSION_SETUP requests

### DIFF
--- a/modules/python/dionaea/smb/smb.py
+++ b/modules/python/dionaea/smb/smb.py
@@ -571,7 +571,10 @@ class smbd(connection):
                     rdata.Bytes = self.outbuf
 
             r /= rdata
-        elif p.getlayer(SMB_Header).Command == SMB_COM_TRANSACTION2:
+        elif Command == SMB_COM_TRANSACTION2:
+            if p.getlayer(SMB_Trans2_Request).Setup == [SMB_TRANS2_SESSION_SETUP]:
+                smblog.info("Possible MS17-010/ETERNALBLUE exploit request!")
+                rstatus = 0xC0000002 #STATUS_NOT_IMPLEMENTED
             r = SMB_Trans2_Response()
         elif Command == SMB_COM_DELETE:
             # specific for NMAP smb-enum-shares.nse support

--- a/modules/python/dionaea/smb/smb.py
+++ b/modules/python/dionaea/smb/smb.py
@@ -572,8 +572,8 @@ class smbd(connection):
 
             r /= rdata
         elif Command == SMB_COM_TRANSACTION2:
-            if p.getlayer(SMB_Trans2_Request).Setup == [SMB_TRANS2_SESSION_SETUP]:
-                smblog.info("Possible MS17-010/ETERNALBLUE exploit request!")
+            if SMB_TRANS2_SESSION_SETUP in p.getlayer(SMB_Trans2_Request).Setup:
+                smblog.info("Possible MS17-010 exploit request!")
                 rstatus = 0xC0000002 #STATUS_NOT_IMPLEMENTED
             r = SMB_Trans2_Response()
         elif Command == SMB_COM_DELETE:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature

##### SUMMARY
Add support for (very) basic handling of TRANS2 SESSION_SETUP requests, which is used to exploit MS17-010 by ETERNALBLUE and the WannaCry/WannaCrypt ransomware.