### PR TITLE
SIP __init__.py cleanup event loop fix #115

### DIFF
--- a/modules/python/dionaea/sip/__init__.py
+++ b/modules/python/dionaea/sip/__init__.py
@@ -93,8 +93,11 @@ class SIPService(ServiceLoader):
 
         if len(daemons) > 0:
             global g_timer_cleanup
-            g_timer_cleanup = pyev.Timer(60.0, 60.0, g_default_loop, cleanup)
-            g_timer_cleanup.start()
+            if g_timer_cleanup is None:
+                g_timer_cleanup = pyev.Timer(60.0, 60.0, g_default_loop, cleanup)
+                g_timer_cleanup.start()
+            else:
+                logger.debug("Cleanup loop already started!")
         return daemons
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix

##### SUMMARY
A simple fix for the SIP python module initializer. Apparently, the module is initialized twice, which causes a segmentation fault in libev. Fixes #115 
