### PR TITLE
Fixes for support recent SambaCry Metasploit module "is_known_pipename"

### DIFF
--- a/modules/python/dionaea/smb/rpcservices.py
+++ b/modules/python/dionaea/smb/rpcservices.py
@@ -3276,7 +3276,7 @@ class SRVSVC(RPCService):
                 self.Max_uses = 0xffffffff
                 self.Current_uses = 1
                 self.Path_pointer = 0x6789
-                self.Passwd_pointer = 0x0
+                self.Passwd_pointer = 0x56789
             elif isinstance(self.__packer,ndrlib.Unpacker):
                 self.ref = self.__packer.unpack_pointer()
                 self.netname = self.__packer.unpack_pointer()
@@ -3321,6 +3321,11 @@ class SRVSVC(RPCService):
                     # Path
                     self.__packer.pack_string_fix(
                         str(data['path']+'\0').encode('utf16')[2:])
+                    # Password
+		    # this is necessary for Metasploit module /exploit/linux/samba/is_known_pipename
+                    self.__packer.pack_string_fix(
+                        str('\0').encode('utf16')[2:])
+
 
     class SERVER_INFO_101(object):
         # 2.2.4.41 SERVER_INFO_101


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
  - Bugfix

##### SUMMARY
Dionaea was unable to capture the payload which dropped by recent Metasploit module 'is_known_pipename" for SambaCry. Recent Metasploit module "is_known_pipename" will call smb_srvsvc_netsharegetinfo() to retrieve the server-side path. It requires Dionaea's response with share folder info: share name, comment, path and the password. The 'password' was missing previously in Dionaea response and this is the fix.

The fix should be able to resolve the reported issue : https://github.com/DinoTools/dionaea/issues/112

Thanks!
<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
