### PR TITLE
Make Dionaea Stealthier Again

### DIFF
--- a/modules/python/dionaea/ftp.py
+++ b/modules/python/dionaea/ftp.py
@@ -101,7 +101,7 @@ RESPONSE = {
     "file_status":                        '213 {value}',
     #"help_msg":                           '214 help: %s',
     "name_sys_type":                      '215 UNIX Type: L8',
-    "welcome_msg":                        "220 Welcome to the ftp service",
+    "welcome_msg":                        "220 Microsoft FTP Service",
     "svc_ready_for_new_user":             '220 Service ready',
     "goodbye_msg":                        '221 Goodbye.',
     "data_cnx_open_no_xfr_in_progress":   '225 data connection open, no transfer in progress',

--- a/modules/python/dionaea/mssql/mssql.py
+++ b/modules/python/dionaea/mssql/mssql.py
@@ -144,7 +144,7 @@ class mssqld(connection):
         if PacketType == TDS_TYPES_PRE_LOGIN:
             r = TDS_Prelogin_Response()
             #FIXME: any better way to initialise this?
-            r.VersionToken.TokenType = 0x00
+            r.VersionToken.TokenType = 0x01
             r.VersionToken.Offset = 26
             r.VersionToken.Len = 6
             r.EncryptionToken.TokenType = 0x01

--- a/modules/python/dionaea/mysql/mysql.py
+++ b/modules/python/dionaea/mysql/mysql.py
@@ -267,7 +267,7 @@ class mysqld(connection):
             except Exception as e:
                 logger.warn("SQL ERROR %s" % e)
                 logger.warn("SQL ERROR in %s" % p.Query)
-                r = MySQL_Result_Error(Message="Learn SQL!")
+                r = MySQL_Result_Error(Message='(1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ' + "'" + query + "'" + ' at line 1")')
         return r
 
     def _handle_com_query_select(self, p, query):

--- a/modules/python/dionaea/smb/include/smbfields.py
+++ b/modules/python/dionaea/smb/include/smbfields.py
@@ -28,10 +28,12 @@
 
 import datetime
 from uuid import UUID
+import random
 
 from .packet import Packet, bind_bottom_up, bind_top_down
 from .fieldtypes import *
 
+source_str = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 #
 # http://www.snia.org/tech_activities/CIFS/CIFS-TR-1p00_FINAL.pdf
@@ -752,11 +754,11 @@ class SMB_Negociate_Protocol_Response(Packet):
         ConditionalField(StrLenField("EncryptionKey", b'',length_from=lambda x: 0),
                          lambda x: not x.Capabilities & CAP_EXTENDED_SECURITY),
         ConditionalField(UnicodeNullField(
-            "OemDomainName", "WORKGROUP"), lambda x: not x.Capabilities & CAP_EXTENDED_SECURITY),
+            "OemDomainName", "".join([random.choice(source_str) for x in xrange(9)])), lambda x: not x.Capabilities & CAP_EXTENDED_SECURITY),
         # In [MS-SMB].pdf page 49,
         # "ServerName" field needed for case without CAP_EXTENDED_SECURITY
         ConditionalField(UnicodeNullField(
-            "ServerName", "HOMEUSER-3AF6FE"), lambda x: not x.Capabilities & CAP_EXTENDED_SECURITY),
+            "ServerName", "".join([random.choice(source_str) for x in xrange(10)])), lambda x: not x.Capabilities & CAP_EXTENDED_SECURITY),
         # with CAP_EXTENDED_SECURITY
         ConditionalField(StrLenField("ServerGUID", b'\x0B\xFF\x65\x38\x54\x7E\x6C\x42\xA4\x3E\x12\xD2\x11\x97\x16\x44',
                                      length_from=lambda x: 16), lambda x: x.Capabilities & CAP_EXTENDED_SECURITY),


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature

##### SUMMARY
My honeypot was easily detected by Nmap.
```sh
$ nmap -T4 -sV ***.***.***.***
...
PORT      STATE    SERVICE      VERSION
21/tcp    open     ftp          Dionaea honeypot ftpd
22/tcp    open     ssh          OpenSSH 7.2p2 Ubuntu 4ubuntu2.2 (Ubuntu Linux; protocol 2.0)
25/tcp    filtered smtp
42/tcp    open     nameserver?
80/tcp    open     honeypot     Dionaea Honeypot httpd
135/tcp   filtered msrpc
139/tcp   filtered netbios-ssn
443/tcp   open     ssl/honeypot Dionaea Honeypot httpd
445/tcp   filtered microsoft-ds
2049/tcp  filtered nfs
12345/tcp filtered netbus
Service Info: OS: Linux; CPE: cpe:/o:linux:linux_kernel
...
```

We could almost avoid this problem by following:
* [Steeve Barbeau's blog: Make Dionaea stealthier for fun and no profit](http://blog.sbarbeau.fr/2012/06/make-dionaea-stealthier-for-fun-and-no.html)
* [Avoiding Dionaea service identification - Security Art Work](https://www.securityartwork.es/2014/06/05/avoiding-dionaea-service-identification/?lang=en).

Still we have to add html file to `/opt/dionaea/var/dionaea/wwwroot` manually, but I believe this patch will harden dionaea.

Regards.
