### PR TITLE
Added more information in the filename of the bistream

### DIFF
--- a/src/processor.c
+++ b/src/processor.c
@@ -365,7 +365,7 @@ ssize_t format_timeval(struct timeval *tv, char *buf, size_t sz)
     written = (ssize_t)strftime(buf, sz, "%Y-%m-%dT%H:%M:%d", gm);
     if ((written > 0) && ((size_t)written < sz))
     {
-      int w = snprintf(buf+written, sz-(size_t)written, ".%06d", tv->tv_usec);
+      int w = snprintf(buf+written, sz-(size_t)written, ".%06ld", tv->tv_usec);
       written = (w > 0) ? written + w : -1;
     }
   }

--- a/src/processor.c
+++ b/src/processor.c
@@ -355,6 +355,24 @@ void proc_streamdumper_ctx_free(void *ctx0)
 	g_free(ctx);
 }
 
+ssize_t format_timeval(struct timeval *tv, char *buf, size_t sz)
+{
+  ssize_t written = -1;
+  struct tm *gm = gmtime(&tv->tv_sec);
+
+  if (gm)
+  {
+    written = (ssize_t)strftime(buf, sz, "%Y-%m-%dT%H:%M:%d", gm);
+    if ((written > 0) && ((size_t)written < sz))
+    {
+      int w = snprintf(buf+written, sz-(size_t)written, ".%06d", tv->tv_usec);
+      written = (w > 0) ? written + w : -1;
+    }
+  }
+  return written;
+}
+
+
 void proc_streamdumper_on_io(struct connection *con, struct processor_data *pd, void *data, int size, enum bistream_direction dir)
 {
 //	g_warning("%s con %p pd %p data %p size %i dir %i", __PRETTY_FUNCTION__, con, pd, data, size, dir);
@@ -381,10 +399,15 @@ void proc_streamdumper_on_io(struct connection *con, struct processor_data *pd, 
 		char path[128];
 		strftime(path, sizeof(path), ((struct streamdumper_config *)pd->processor->config)->path, &t);
 		char prefix[512];
-		snprintf(prefix, sizeof(prefix), "%s-%i-%s-",
+		char timebuf[28];
+		format_timeval(&con->stats.start, timebuf, sizeof(timebuf));
+		snprintf(prefix, sizeof(prefix), "%s-%s-%i-%s-%i-%s-",
 				 con->protocol.name,
+				 con->local.ip_string,
 				 ntohs(con->local.port),
-				 con->remote.ip_string);
+				 con->remote.ip_string,
+				 ntohs(con->remote.port),
+				 timebuf);
 
 		struct stat s;
 		if( stat(path, &s) != 0 &&

--- a/src/processor.c
+++ b/src/processor.c
@@ -357,19 +357,17 @@ void proc_streamdumper_ctx_free(void *ctx0)
 
 ssize_t format_timeval(struct timeval *tv, char *buf, size_t sz)
 {
-  ssize_t written = -1;
-  struct tm *gm = gmtime(&tv->tv_sec);
+	ssize_t written = -1;
+	struct tm *gm = gmtime(&tv->tv_sec);
 
-  if (gm)
-  {
-    written = (ssize_t)strftime(buf, sz, "%Y-%m-%dT%H:%M:%d", gm);
-    if ((written > 0) && ((size_t)written < sz))
-    {
-      int w = snprintf(buf+written, sz-(size_t)written, ".%06ld", tv->tv_usec);
-      written = (w > 0) ? written + w : -1;
-    }
-  }
-  return written;
+	if (gm) {
+		written = (ssize_t)strftime(buf, sz, "%Y-%m-%dT%H:%M:%d", gm);
+		if ((written > 0) && ((size_t)written < sz)) {
+			int w = snprintf(buf+written, sz-(size_t)written, ".%06ld", tv->tv_usec);
+			written = (w > 0) ? written + w : -1;
+		}
+	}
+	return written;
 }
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature

##### SUMMARY
<!--- Describe your change. -->
The bistream contains information about the HTTP request.
The dionaea log contains information about the source, destination and timestamp of the event.

With this change I have added more information to the bistream filename, so now it contains all the information about one specific event. Therefore, it is easier to parse (e.g. logstash).

Before it was not possible to correlate the information.

The new format is the following:
`protocol-dst_ip-dst_port-src_ip-src_port-timestamp_iso8601-random`

e.g. 
`httpd-192.168.10.50-80-192.168.10.60-54594-2018-02-15T15:17:15.319777-zIalQz`



Fixes #148 
