### PR TITLE
libtool: Version mismatch error

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -6,6 +6,11 @@ FAQ
 
 Build/Install
 -------------
+I got these error while installation from source code 
+"libtool: Version mismatch error.  This is libtool 2.4.6, but the
+libtool: definition of this LT_INIT comes from libtool 2.4.2.
+libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
+libtool: and run autoconf again.".
 
 I get gcc: command not found?
 


### PR DESCRIPTION
I got these error while installation from source code 
"libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from libtool 2.4.2.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.".

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature
 - Bugfix
 - Documentation
 - ...

##### SUMMARY
<!--- Describe your change. -->

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
