### PR TITLE
get rid of one of the compile time warnings about not using the chdir

### DIFF
--- a/src/dionaea.c
+++ b/src/dionaea.c
@@ -725,7 +725,10 @@ opt->stdOUT.filter);
 			g_error("Could not chroot(\"%s\") (%s)", opt->root, strerror(errno));
 		} else
 		{
-			chdir("/");
+			if ( chdir("/") != 0 ) {
+				g_error("Could change to root directory '/' ... this shuoldn't happen exitting.\nErr: (%s)", strerror(errno));
+				return EXIT_FAILURE;
+			}
 		}
 	}
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix

##### SUMMARY
process errorcode from the chdir("/") to get rid of the warning.
