### PR TITLE
introduce the PYTHON_SITELIB variable to the makefile 

### DIFF
--- a/modules/python/dionaea/Makefile.am
+++ b/modules/python/dionaea/Makefile.am
@@ -2,6 +2,9 @@
 
 AUTOMAKE_OPTIONS = foreign
 
+PYTHON_SITELIB=$(pkglibdir)"/python"
+
+
 PYSCRIPTS = blackhole.py
 PYSCRIPTS += emu_scripts/__init__.py
 PYSCRIPTS += emu_scripts/handler.py
@@ -87,11 +90,11 @@ PYSCRIPTS += upnp/upnp.py
 
 
 all: $(PYSCRIPTS)
-	
+
 
 install-data-am: all
 	for i in $(PYSCRIPTS); do \
-		location=$(DESTDIR)$(pkglibdir)"/python/dionaea/$$i"; \
+		location=$(DESTDIR)$(PYTHON_SITELIB)"/dionaea/$$i"; \
 		scriptdir=`dirname "$$location"`; \
 		if [ ! -d $$scriptdir ]; then \
 			$(mkinstalldirs) $$scriptdir; \


### PR DESCRIPTION
introduce the PYTHON_SITELIB variable to the makefile so it can be driven by the build

##### ISSUE TYPE
 - Feature

##### SUMMARY
Adding the variable would make it easier to change the default python sitelibs path during the build time without having to patch the application
