### PR TITLE
fix compilation on RHEL7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -580,7 +580,7 @@ AC_ARG_WITH(cython-dir,
 				      [cython_dir="$withval"],[cython_dir=$PATH])
 
 if test x$enable_cython = "xyes" ; then
-	AC_PATH_PROGS(CYTHON_BIN, [cython3 cython], "no", $cython_dir)
+	AC_PATH_PROGS(CYTHON_BIN, [cython3.4 cython3 cython], "no", $cython_dir)
 	if test "x$CYTHON_BIN" == "xno" ; then
 		enable_cython="no"
 	fi


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix

##### SUMMARY
<!--- Describe your change. -->
On RHEL7 the python3 binary is actually naed python3.4.
The usual python3 is not available there.
Searching explicitly for python3.4 amongst the others will fix the issue.
<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
