### PR TITLE
fix hardcoded /lib dir

### DIFF
--- a/modules/python/module.c
+++ b/modules/python/module.c
@@ -348,7 +348,7 @@ static bool new(struct dionaea *dionaea)
 
 	Py_Initialize();
 
-	runtime.sys_path = g_string_new(PREFIX"/lib/dionaea/python/");
+	runtime.sys_path = g_string_new(LIBDIR"/dionaea/python/");
 
 	PyObject *name = PyUnicode_FromString("traceback");
 	runtime.traceback.module = PyImport_Import(name);
@@ -366,7 +366,7 @@ static bool new(struct dionaea *dionaea)
 
 	for (sys_path = sys_paths; *sys_path; sys_path++) {
 		if( strcmp(*sys_path, "default") == 0 ) {
-			sprintf(relpath, "sys.path.insert(%i, '%s/lib/dionaea/python/')", i, PREFIX);
+			sprintf(relpath, "sys.path.insert(%i, '%s/dionaea/python/')", i, LIBDIR);
 		} else {
 			// ToDO
 		/*	if( *sys_path == '/' )

--- a/src/modules.c
+++ b/src/modules.c
@@ -114,7 +114,7 @@ void modules_load(gchar **names)
   for (name = names; *name; name++) {
 
 		gchar module_path[1024];
-		if( g_snprintf(module_path, 1023, PREFIX"/lib/dionaea/%s.so", *name) == -1 )
+		if( g_snprintf(module_path, 1023, LIBDIR"/dionaea/%s.so", *name) == -1 )
 			return;
 
 		g_message("loading module %s (%s)", *name, module_path);


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature
 - Bugfix

##### SUMMARY
<!--- Describe your change. -->
on 64 platform the RedHat based distrubutions prefer the lib directories to
have different names for 64 bit (lib64) and 32 bit (lib).
This fix allows to configure that at compile time.
<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
