### PR TITLE
Do not use obsolete macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ AC_C_BIGENDIAN
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_MAKE_SET
-AC_PROG_LIBTOOL
+LT_INIT
 
 AC_CHECK_HEADERS([stdint.h stdlib.h string.h strings.h unistd.h netpacket/packet.h execinfo.h linux/sockios.h])
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix

##### SUMMARY
<!--- Describe your change. -->
Hello,
during the package review for Fedora distribution it was identified that there is used obsolete macro AC_PROG_LIBTOOL. The macro LT_INIT should be used instead.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1564716

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
