### PR TITLE
Fix reconnect with IP only

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -1143,7 +1143,7 @@ void connection_reconnect_timeout_cb(EV_P_ struct ev_timer *w, int revents)
 	ev_timer_stop(EV_A_ w);
 	connection_set_state(con, connection_state_none);
 
-	if( !parse_addr(con->remote.hostname, NULL, ntohs(con->remote.port), &sa, &socket_domain, &sizeof_sa) )
+	if( con->remote.hostname != NULL && !parse_addr(con->remote.hostname, NULL, ntohs(con->remote.port), &sa, &socket_domain, &sizeof_sa) )
 	{ /* domain */
 		if( con->remote.dns.resolved_address_count == con->remote.dns.current_address )
 		{ /* tried all resolved ips already */


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix

##### SUMMARY
<!--- Describe your change. -->

If an IP address is used to make an remote connection it will fail with a segmentation fault if the connection has to be reestablished. This will not happen if an hostname is used.

Looks like the bug has been introduced with #28 but should be fixed now.

* Refs #138 
* Fixes #144

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
