### PR TITLE
Use classes to provide additional information on connection errors

### DIFF
--- a/modules/python/binding.pyx
+++ b/modules/python/binding.pyx
@@ -431,13 +431,19 @@ cdef extern from "processor.h":
 	void c_python_processor_bistream_create "python_processor_bistream_create"(c_connection *con)
 
 
-cdef extern from "protocol.h":
-	cpdef enum:
-		ECONDNSTIMEOUT
-		ECONUNREACH
-		ECONNOSUCHDOMAIN
-		ECONMANY
-
+# Works only with Cython >= 0.21
+# Drop support for Ubuntu 14.04 and re-enable it
+# cdef extern from "protocol.h":
+# 	cpdef enum:
+# 		ECONDNSTIMEOUT
+# 		ECONUNREACH
+# 		ECONNOSUCHDOMAIN
+# 		ECONMANY
+ctypedef enum:
+	ECONDNSTIMEOUT   = 0,
+	ECONUNREACH      = 1,
+	ECONNOSUCHDOMAIN = 2,
+	ECONMANY         = 4
 
 cdef class connection:
 	"""the connection"""

--- a/modules/python/binding.pyx
+++ b/modules/python/binding.pyx
@@ -188,7 +188,7 @@ cdef extern from "../../include/connection.h":
 	int c_connection_unref "connection_unref"(c_connection *)
 	
 	void c_PyErr_Print "PyErr_Print"()
-	
+
 
 cdef class node_info:
 	"""node_info stores information about a node"""
@@ -431,6 +431,12 @@ cdef extern from "processor.h":
 	void c_python_processor_bistream_create "python_processor_bistream_create"(c_connection *con)
 
 
+cdef extern from "protocol.h":
+	cpdef enum:
+		ECONDNSTIMEOUT
+		ECONUNREACH
+		ECONNOSUCHDOMAIN
+		ECONMANY
 
 
 cdef class connection:
@@ -814,7 +820,35 @@ cdef c_bool handle_error_cb(c_connection *con, c_connection_error err) except *:
 #	print "connect_error_cb"
 	cdef connection instance
 	instance = <connection>c_connection_protocol_ctx_get(con)
-	r = instance.handle_error(err)
+	i = None
+	from dionaea import exception
+	if err == ECONDNSTIMEOUT:
+		i = exception.ConnectionDNSTimeout(
+			connection=instance,
+			error_id=err
+		)
+	elif err == ECONUNREACH:
+		i = exception.ConnectionUnreachable(
+			connection=instance,
+			error_id=err
+		)
+	elif err == ECONNOSUCHDOMAIN:
+		i = exception.ConnectionNoSuchDomain(
+			connection=instance,
+			error_id=err
+		)
+	elif err == ECONMANY:
+		i = exception.ConnectionTooMany(
+			connection=instance,
+			error_id=err
+		)
+	else:
+		i = exception.ConnectionUnknownError(
+			connection=connection,
+			error_id=err
+		)
+
+	r = instance.handle_error(i)
 	return <bint>r
 
 cdef c_bool handle_timeout_sustain_cb(c_connection *con, void *ctx) except *:

--- a/modules/python/dionaea/exception.py
+++ b/modules/python/dionaea/exception.py
@@ -13,3 +13,47 @@ class LoaderError(DionaeaError):
 
 class ServiceConfigError(DionaeaError):
     pass
+
+
+class ConnectionError(DionaeaError):
+    def __init__(self, connection=None, error_id=None):
+        self.connection = connection
+        self.error_id = error_id
+
+
+class ConnectionDNSTimeout(ConnectionError):
+    def __str__(self):
+        return "Timeout resolving the hostname/domain: %s" % (
+            self.connection.remote.hostname
+        )
+
+
+class ConnectionUnreachable(ConnectionError):
+    def __str__(self):
+        hostname = self.connection.remote.hostname
+        if hostname is None or hostname == "":
+            hostname = self.connection.remote.host
+
+        return "Could not connect to host(s): %s:%d" % (
+            hostname,
+            self.connection.remote.port
+        )
+
+
+class ConnectionNoSuchDomain(ConnectionError):
+    def __str__(self):
+        return "Could not resolve the domain: %s" % (
+            self.connection.remote.hostname
+        )
+
+
+class ConnectionTooMany(ConnectionError):
+    def __str__(self):
+        return "Too many connections"
+
+
+class ConnectionUnknownError(ConnectionError):
+    def __str__(self):
+        return "Unknown error occured: error_id=%d" % (
+            self.error_id
+        )

--- a/modules/python/dionaea/hpfeeds.py
+++ b/modules/python/dionaea/hpfeeds.py
@@ -256,7 +256,7 @@ class hpclient(connection):
         return 1
 
     def handle_error(self, err):
-        logger.warn('hpclient error {0}'.format(err))
+        logger.warn(str(err))
         self.connected = False
         return 1
 


### PR DESCRIPTION
New error classes to add additional information when calling the
handle_error() function. The function argument has changed from int to
class instance.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix

##### SUMMARY
<!--- Describe your change. -->

New class to provide additional information when handling connection errors

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
