### PR TITLE
Allow binding to meta addresses 0.0.0.0 and ::

### DIFF
--- a/modules/python/dionaea/services.py
+++ b/modules/python/dionaea/services.py
@@ -141,9 +141,25 @@ def new():
 
     if mode == 'manual':
         addrs = {}
+        whildcard_addresses = {'0.0.0.0', '::'}
 
         addresses = dionaea_config.get("listen.addresses")
         ifaces = g_dionaea.getifaddrs()
+        if whildcard_addresses.intersection(addresses):
+            listen_ifaces = dionaea_config.get("listen.interfaces")
+            if listen_ifaces is not None:
+                for iface in listen_ifaces:
+                    if iface not in addrs:
+                        addrs[iface] = []
+                    for whildcard_address in whildcard_addresses.intersection(addresses):
+                        addrs[iface].append(whildcard_address)
+            else:
+                for iface in ifaces.keys():
+                    if iface not in addrs:
+                        addrs[iface] = []
+                    for whildcard_address in whildcard_addresses.intersection(addresses):
+                        addrs[iface].append(whildcard_address)
+
         for iface in ifaces.keys():
             afs = ifaces[iface]
             for af in afs.keys():


### PR DESCRIPTION
In dionaea.cfg file 'listen.addresses=0.0.0.0,::' (listening on all addresses on local machine) will now work.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature

##### SUMMARY
<!--- Describe your change. -->

Binding to meta addresses :: and 0.0.0.0 (e.g. listening on all addresses on local machine) will now work, if 'listen.addresses=0.0.0.0,::' is specified in dionaea.cfg

<!- --
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
