### PR TITLE
arguments of fwrite were swapped

### DIFF
--- a/modules/emu/hooks.c
+++ b/modules/emu/hooks.c
@@ -1223,7 +1223,7 @@ BOOL WriteFile(
 
 	if( tf->fd != -1 )
 	{
-		if( fwrite(lpBuffer, nNumberOfBytesToWrite, 1, tf->fh) != 1 )
+		if( fwrite(lpBuffer, 1, nNumberOfBytesToWrite, tf->fh) != 1 )
 		{
 			g_warning("fwrite failed %s",  strerror(errno));
 		}

--- a/modules/emu/hooks.c
+++ b/modules/emu/hooks.c
@@ -1490,7 +1490,7 @@ uint32_t user_hook__lwrite(struct emu_env *env, struct emu_env_hook *hook, ...)
 
 	if( tf->fd != -1 )
 	{
-		if( fwrite(lpBuffer, nNumberOfBytesToWrite, 1, tf->fh) != 1 )
+		if( fwrite(lpBuffer, 1, nNumberOfBytesToWrite, tf->fh) != 1 )
 		{
 			g_warning("fwrite failed %s",  strerror(errno));
 		}


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix

##### SUMMARY
The arguments of fwrite were swapped. It seems to me that the OS doesn't support these parameters like this because the semantics is slightly different.
Should fix the issue with the capped max file size of the binaries.
A typical error I made in some of my code too. 
