### PR TITLE
Add smb port option

### DIFF
--- a/doc/source/service/smb.rst
+++ b/doc/source/service/smb.rst
@@ -39,6 +39,8 @@ appreciated.
 Example config
 --------------
 
+The default port is `445`; it can be changed via the `port` stanza.
+
 .. literalinclude:: ../../../conf/services/smb.yaml
     :language: yaml
     :caption: services/smb.yaml

--- a/modules/python/dionaea/smb/__init__.py
+++ b/modules/python/dionaea/smb/__init__.py
@@ -25,6 +25,6 @@ class SMBService(ServiceLoader):
         except ServiceConfigError as e:
             smblog.error(e.msg, *e.args)
             return
-        daemon.bind(addr, 445, iface=iface)
+        daemon.bind(addr, daemon.config.port, iface=iface)
         daemon.listen()
         return daemon

--- a/modules/python/dionaea/smb/extras.py
+++ b/modules/python/dionaea/smb/extras.py
@@ -22,6 +22,7 @@ class SmbConfig(object):
         self.primary_domain = "WORKGROUP"
         self.server_name = "HOMEUSER-3AF6FE"
         self.shares = {}
+        self.port = 445
 
         default_shares = {
             "ADMIN$" : {
@@ -52,7 +53,8 @@ class SmbConfig(object):
             "oem_domain_name",
             "os_type",
             "primary_domain",
-            "server_name"
+            "server_name",
+            "port"
         ]
         for name in value_names:
             value = config.get(name)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature

##### SUMMARY
Allow binding smb to a port other than `445`. Sort of a workaround for the permission issues (#241, #205) for smb specifically. Useful in a Docker container where the port can be mapped onto `445` on the host.

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
