### PR TITLE
New feature to upload binaries to Amazon S3 buckets

### DIFF
--- a/conf/ihandlers/s3.yaml
+++ b/conf/ihandlers/s3.yaml
@@ -1,0 +1,16 @@
+- name: s3
+  config:
+    # Upload dionaea captured samples to Amazon AWS S3 bucket
+    # Amazon AWS S3 credentials
+    access_key_id: "AKIAIXEXAMPLE"
+    secret_access_key: "6WVE5LkETVL91nTKgGnm/YxJ+EXAMPLE"
+    bucket_name: "my-dionaea-bucket"
+    region_name: "eu-west-1"
+    # Alternate endpoint URL 
+    # Normally Boto 3 will automatically construct appropriate URL
+    # By default, we can leave this value to blank
+    endpoint_url: 
+    # Whether or not to validate the S3 certificate
+    verify: True
+    # Specify the destination folder in S3 for the upload
+    s3_dest_folder: "dionaea-capture/"

--- a/doc/source/ihandler/index.rst
+++ b/doc/source/ihandler/index.rst
@@ -33,6 +33,7 @@ List of available ihandlers
     log_sqlite
     nfq
     p0f
+    s3
     store
     submit_http
     submit_http_post

--- a/doc/source/ihandler/s3.rst
+++ b/doc/source/ihandler/s3.rst
@@ -1,0 +1,11 @@
+s3
+==
+
+Upload unique captured binaries to Amazon S3 bucket
+
+Example config
+--------------
+
+.. literalinclude:: ../../../conf/ihandlers/s3.yaml
+   :language: yaml
+   :caption: ihandlers/s3.yaml

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -82,6 +82,7 @@ Install required build dependencies before configuring and building dionaea. ('t
         python3-dev \
         python3-bson \
         python3-yaml \
+        python3-boto3 \
         ttf-liberation
 
 After all dependencies have been installed successfully create a build directory and run :code:`cmake` to setup the build process.
@@ -175,7 +176,8 @@ Install required build dependencies before configuring and building dionaea.
         python3 \
         python3-dev \
         python3-bson \
-        python3-yaml
+        python3-yaml \
+        python3-boto3 
 
 After all dependencies have been installed successfully create a build directory and run :code:`cmake` to setup the build process.
 

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -135,6 +135,7 @@ install_available_python_config(
         log_sqlite.yaml.in
         nfq.yaml
         p0f.yaml
+        s3.yaml
         store.yaml
         submit_http_post.yaml
         submit_http.yaml

--- a/modules/python/dionaea/s3.py
+++ b/modules/python/dionaea/s3.py
@@ -1,0 +1,59 @@
+from dionaea.core import ihandler, incident, g_dionaea
+from dionaea import pyev, IHandlerLoader
+
+import logging
+import socket
+import boto3
+
+logger = logging.getLogger('s3')
+logger.setLevel(logging.DEBUG)
+
+
+class S3HandlerLoader(IHandlerLoader):
+    name = "s3"
+
+    @classmethod
+    def start(cls, config=None):
+        return s3handler("*", config=config)
+
+
+class s3handler(ihandler):
+    def __init__(self, path, config=None):
+        logger.debug("%s ready!" % (self.__class__.__name__))
+        ihandler.__init__(self, path)
+
+        self.bucket_name = config.get("bucket_name")
+        self.region_name = config.get("region_name")
+        self.access_key_id = config.get("access_key_id")
+        self.secret_access_key = config.get("secret_access_key")
+        self.endpoint_url = config.get("endpoint_url")
+        self.verify = config.get("verify")
+        self.s3_dest_folder = config.get("s3_dest_folder")
+        self.s3 = ''
+
+        self.loop = pyev.default_loop()
+
+    def handle_incident(self, icd):
+        pass
+
+    def handle_incident_dionaea_download_complete_unique(self, icd):
+
+        # Dionaea will upload unique samples to Amazon S3 bucket with Boto3 (AWS SDK Python)        
+        # Create an S3 client
+        try:
+            self.s3 = boto3.client(
+                    's3',
+                    self.region_name,
+                    aws_access_key_id=self.access_key_id,
+                    aws_secret_access_key=self.secret_access_key,
+                    endpoint_url=self.endpoint_url or None,
+                    verify=self.verify)
+
+            # Uploads the given file using a Boto 3 managed uploader, which will split up large
+            # files automatically and upload parts in parallel.
+            self.s3.upload_file(icd.file, self.bucket_name, self.s3_dest_folder+icd.md5hash)
+            logger.info("File (MD5) uploaded to S3 bucket: {0}".format(icd.md5hash))
+
+        except Exception as e:
+            logger.warn("S3 exception: {0}".format(e))
+


### PR DESCRIPTION
New feature to upload unique captured binaries to Amazon S3 bucket



##### ISSUE TYPE
 - Feature


##### SUMMARY
<!--- Describe your change. -->
- Add new ihandlers-available s3.yaml, with config settings
- Add new python file s3.py
- Modify modules/python/CMakeLists.txt to include the new ihandler s3.yaml
- Update documentation installation.rst to include the required dependency package 'python3-boto3'
- This Amazon S3 upload feature is disabled by default, it can be enabled with s3 ihandler manually

##### Steps to test the new feature:
1. Configure /opt/dionaea/etc/dionaea/ihandlers-available/s3.yaml with S3 credentials, bucket, region
2. Enable the new ihandler s3.yaml
>/opt/dionaea/etc/dionaea/ihandlers-enabled$ sudo ln -s ../ihandlers-available/s3.yaml s3.yaml

3. Run dionaea with debug mode and test it with doublepulsar payload (e.g. publicly or custom Metapsloit module https://github.com/ElevenPaths/Eternalblue-Doublepulsar-Metasploit.git). In this case, the dionaea log file indicated the captured binary MD5: b9dca74a46f6bfc99d65c7acc230ac2c was uploaded successfully to Amazon S3 bucket

> [02122018 19:05:21] log_sqlite /dionaea/logsql.py:697: accepted connection from 192.168.100.111:41606 to 192.168.100.222:445 (id=2)
[02122018 19:05:21] SMB /dionaea/smb/smb.py:632: Possible DoublePulsar connection attempts..
[02122018 19:05:21] SMB /dionaea/smb/smb.py:644: DoublePulsar request opcode: 23 command: ping
[02122018 19:05:21] SMB /dionaea/smb/smb.py:632: Possible DoublePulsar connection attempts..
[02122018 19:05:21] SMB /dionaea/smb/smb.py:644: DoublePulsar request opcode: c8 command: exec
[02122018 19:05:21] SMB /dionaea/smb/smb.py:632: Possible DoublePulsar connection attempts..
[02122018 19:05:21] SMB /dionaea/smb/smb.py:644: DoublePulsar request opcode: c8 command: exec
[02122018 19:05:21] SMB /dionaea/smb/smb.py:632: Possible DoublePulsar connection attempts..
[02122018 19:05:21] SMB /dionaea/smb/smb.py:644: DoublePulsar request opcode: c8 command: exec
[02122018 19:05:21] SMB /dionaea/smb/smb.py:656: DoublePulsar payload receiving..
[02122018 19:05:21] SMB /dionaea/smb/smb.py:661: DoublePulsar payload - MD5 (before XOR decryption): 2545e3ccdcac4dab41b4883f33b1e786
[02122018 19:05:21] SMB /dionaea/smb/smb.py:663: DoublePulsar payload - MD5 (after XOR decryption ): 217244dbc9cb2f7d7f73489a79ea6110
[02122018 19:05:21] SMB /dionaea/smb/smb.py:672: DoublePulsar payload - MZ header found...
[02122018 19:05:21] SMB /dionaea/smb/smb.py:676: DoublePulsar payload - Save to disk
[02122018 19:05:21] log_sqlite /dionaea/logsql.py:799: complete for attackid 2
[02122018 19:05:21] requests.packages.urllib3.connectionpool /usr/lib/python3/dist-packages/urllib3/connectionpool.py:761: Starting new HTTPS connection (1): my-dionaea-bucket.s3.amazonaws.com
[02122018 19:05:21] s3 /dionaea/s3.py:55: File (MD5) uploaded to S3 bucket: b9dca74a46f6bfc99d65c7acc230ac2c

4. We should observe the binary being uploaded to Amazon S3 bucket, under the default directory 'dionaea-capture'.

