### PR TITLE
Add SHA256 utility function

### DIFF
--- a/modules/python/dionaea/util.py
+++ b/modules/python/dionaea/util.py
@@ -56,6 +56,15 @@ def sha512file(filename):
     """
     return hashfile(filename, hashlib.sha512())
 
+def sha256file(filename):
+    """
+    Compute sha256 checksum of file.
+
+    :param str filename: File to read
+    :return: SHA256 checksum as hex string
+    :rtype: str
+    """
+    return hashfile(filename, hashlib.sha256())
 
 def hashfile(filename, digest):
     """


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature

##### SUMMARY
This adds a new function in the utils library to calculate the SHA256 hash for a file, using the same logic as existing functions for MD5 and SHA512 

I propose this addition as there are libraries of hashes that do not support SHA512 hashes, while SHA256 hashes are supported. Generally, my experience has been that SHA256 hashes are more widely used for malware identification, etc.

Inclusion of the function here would allow individual output modules the option of using this hash algorithm, without requiring any changes to existing code.
