### PR TITLE
Updating default sip db path to reflect 0.8.0 changes

### DIFF
--- a/modules/python/dionaea/sip/extras.py
+++ b/modules/python/dionaea/sip/extras.py
@@ -77,7 +77,7 @@ class SipConfig(object):
 
         self.root_path = os.getcwd()
 
-        self.users = os.path.join(self.root_path, config.get("users", "var/dionaea/sipaccounts.sqlite"))
+        self.users = os.path.join(self.root_path, config.get("users", "var/lib/dionaea/sip/accounts.sqlite"))
 
         self._conn = sqlite3.connect(self.users)
         self._cur = self._conn.cursor()


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix

##### SUMMARY
Updating default sip db path to reflect 0.8.0 changes. Can result in an error if a config is not specified.