### PR TITLE
Replace PyUnicode_GetSize in python module

### DIFF
--- a/modules/python/module.c
+++ b/modules/python/module.c
@@ -972,18 +972,18 @@ static char *pyobjectstring(PyObject *obj)
 	if( PyType_Check(obj) )
 		return g_strdup(((PyTypeObject* ) obj)->tp_name);
 
-	if( PyUnicode_Check(obj) )
+	if( PyUnicode_Check(obj) ) {
 		pyobjectstr = obj;
-	else 
-	if( (pyobjectstr = PyObject_Repr(obj)) != NULL )
-	{
-		if( PyUnicode_Check(pyobjectstr) == 0 )
-		{
-			Py_XDECREF(pyobjectstr);
-			return g_strdup("<!utf8>");
+	} else {
+		if( (pyobjectstr = PyObject_Repr(obj)) != NULL ) {
+			if( PyUnicode_Check(pyobjectstr) == 0 ) {
+				Py_XDECREF(pyobjectstr);
+				return g_strdup("<!utf8>");
+			}
+		} else {
+			return g_strdup("<!repr>");
 		}
-	} else
-		return g_strdup("<!repr>");
+	}
 
 	Py_ssize_t pysize = PyUnicode_GetSize(pyobjectstr);
 	wchar_t * str = (wchar_t *) malloc((pysize + 1) * sizeof(wchar_t));

--- a/modules/python/module.c
+++ b/modules/python/module.c
@@ -985,10 +985,8 @@ static char *pyobjectstring(PyObject *obj)
 		}
 	}
 
-	Py_ssize_t pysize = PyUnicode_GetSize(pyobjectstr);
-	wchar_t * str = (wchar_t *) malloc((pysize + 1) * sizeof(wchar_t));
-	PyUnicode_AsWideChar(pyobjectstr, str, pysize);
-	str[pysize] = '\0';
+	Py_ssize_t pysize;
+	wchar_t *str = PyUnicode_AsWideCharString(pyobjectstr, &pysize);
 
 	if( pyobjectstr != obj )
 		Py_DECREF(pyobjectstr);
@@ -1002,7 +1000,7 @@ static char *pyobjectstring(PyObject *obj)
 
 	// convert
 	wcstombs(cstr, str, csize + 1);
-	free(str);
+	PyMem_Free(str);
 	return cstr;
 }
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix

##### SUMMARY
<!--- Describe your change. -->

This replaces some functions marked as deprecated in Python 3.7.
It fixes #225 

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
