### PR TITLE
Update mysql.py

### DIFF
--- a/modules/python/dionaea/mysql/mysql.py
+++ b/modules/python/dionaea/mysql/mysql.py
@@ -239,6 +239,9 @@ class mysqld(connection):
                 r.append(x)
             r.append(MySQL_Result_EOF(ServerStatus=0x002))
 
+        elif re.match(b'attach\s+database', p.Query, re.I):
+            return MySQL_Result_Error(Message="#1064 - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use")
+
         else:
             p.show()
             try:

--- a/modules/python/dionaea/mysql/mysql.py
+++ b/modules/python/dionaea/mysql/mysql.py
@@ -239,7 +239,7 @@ class mysqld(connection):
                 r.append(x)
             r.append(MySQL_Result_EOF(ServerStatus=0x002))
 
-        elif re.match(b'attach\s+database', p.Query, re.I):
+        elif re.match(b'attach', p.Query, re.I):
             return MySQL_Result_Error(Message="#1064 - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use")
 
         else:


### PR DESCRIPTION
Blacklist the ATTACH DATABASE command to prevent attaching to local SQLite3 databases

##### ISSUE TYPE
 - Bugfix

##### SUMMARY
Dionaea honeypot allows the "ATTACH DATABASE" command, which can be used to attach to any local SQLite database on which the Dionaea process has read access. If Dionaea has write access, it is even possible to make changes to the database. This includes the logging database (when used) and sipaccounts database.

This PR blacklists any query that matches the attach\s+database regex.
