### PR TITLE
Fix bug not detecting linux/sockios.h correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,11 @@ find_package(EV REQUIRED)
 find_package(CURL)
 find_package(PCAP)
 
+include(CheckIncludeFile)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    check_include_file(linux/sockios.h HAVE_LINUX_SOCKIOS_H)
+endif()
+
 include(CheckCSourceRuns)
 include(CheckIPv4MappedIPv6)
 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -21,4 +21,6 @@
 
 #cmakedefine CAN_BIND_IPV4_MAPPED_IPV6
 
+#cmakedefine HAVE_LINUX_SOCKIOS_H 1
+
 #endif /* CONFIG_H */

--- a/src/dionaea.c
+++ b/src/dionaea.c
@@ -780,6 +780,9 @@ opt->stdOUT.filter);
 		{
 			g_error("Could not change user");
 		}
+#ifndef HAVE_LINUX_SOCKIOS_H
+		g_info("Dropping privileges and binding to ports < 1024 is only supported on Linux.");
+#endif
 	}
 
 	options_free(opt);


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix

##### SUMMARY
<!--- Describe your change. -->

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->

On Linux we include linux/sockios.h to provide some additional
functions like dropping privileges and binding to ports < 1024. We
detect if the include file is available and provide the result as
environment variable in the config.h.

This fixes #241 and maybe refs #205