### PR TITLE
python/ftp - Hotfix FTPDataConnect.__init__ requiring defaults for args

### DIFF
--- a/modules/python/dionaea/ftp.py
+++ b/modules/python/dionaea/ftp.py
@@ -710,7 +710,7 @@ class FTPDataCon(connection):
 class FTPDataConnect(FTPDataCon):
     protocol_name = "ftpdataconnect"
 
-    def __init__(self, host, port, ctrl):
+    def __init__(self, host=None, port=None, ctrl=None):
         FTPDataCon.__init__(self, ctrl)
         self.connect(host, port)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix

##### SUMMARY
Fixes #324. Adds dummy defaults to the FTPDataConnect constructor, as required by PR #318 (commit acc8bc87723181459081e525126368f30edecd81)

I was thinking about adding further sanity checks for the values, but then I checked the fix in the PR and it seems adequate to leave it like it is now.
